### PR TITLE
auditbeat-os - (few changes)

### DIFF
--- a/extractors/OS/auditbeat.yaml
+++ b/extractors/OS/auditbeat.yaml
@@ -11,7 +11,7 @@ provides-streams:
 - AUTHENTICATION
 - AUDITD
 master-filters:
-- \"type\"\:\"auditbeat\"
+- '\"type\"\:\"auditbeat\"'
 event-details:
 - first-match: '\"category\":\[\"authentication\"'
   decoder: json
@@ -34,10 +34,71 @@ event-details:
         Action: LOGIN
         Status: FAILED
         AuthProto: '-'
-        Reason: '-'
+        Reason: BAD_USER_PASSWORD
       translate:
         user[name]: User
         source[ip]: SrcIP
+
+    'authenticated-failure':
+      annotate:
+        Stream: AUTHENTICATION
+        Action: LOGIN
+        Status: FAILED
+        AuthProto: '-'
+        Reason: '-'
+      translate:
+        user[name]: User
+        source[ip]: SrcIP 
+
+    'acquired-credentials-success':
+      annotate:
+        Stream: AUDITD
+        Action: ACQUIRED_CREDENTIALS
+        Status: PASSED
+      translate:
+        user[name]: User
+        process[executable]: Process
+        process[args]: ProcessArgs
+
+    'disposed-credentials-success':
+      annotate:
+        Stream: AUDITD
+        Action: DISPOSED_CREDENTIALS
+        Status: PASSED
+      translate:
+        user[name]: User
+        process[executable]: Process
+        process[args]: ProcessArgs 
+
+    'refreshed-credentials-success':
+      annotate:
+        Stream: AUDITD
+        Action: REFRESHED_CREDENTIALS
+        Status: PASSED
+      translate:
+        user[name]: User
+        process[executable]: Process
+        process[args]: ProcessArgs  
+
+    'started-session-success':
+      annotate:
+        Stream: AUDITD
+        Action: SESSION_START
+        Status: PASSED
+      translate:
+        user[name]: User
+        process[executable]: Process
+        process[args]: ProcessArgs   
+
+    'ended-session-success':
+      annotate:
+        Stream: AUDITD
+        Action: SESSION_END
+        Status: PASSED
+      translate:
+        user[name]: User
+        process[executable]: Process
+        process[args]: ProcessArgs       
 
   fallback:
     annotate:
@@ -138,6 +199,16 @@ event-details:
         user[name]: User
         process[executable]: Process
         process[args]: ProcessArgs
+
+    'ran-command':
+      annotate:
+        Stream: AUDITD
+        Action: USER_COMMAND_EXECUTED
+        Status: PASSED
+      translate:
+        user[name]: User
+        process[working_directory]: Process
+        process[args]: ProcessArgs    
 
   fallback:
     annotate:

--- a/extractors/OS/auditbeat.yaml
+++ b/extractors/OS/auditbeat.yaml
@@ -52,7 +52,7 @@ event-details:
     'acquired-credentials-success':
       annotate:
         Stream: AUDITD
-        Action: ACQUIRED_CREDENTIALS
+        Action: CREDENTIALS_ACQUIRED
         Status: PASSED
       translate:
         user[name]: User
@@ -62,7 +62,7 @@ event-details:
     'disposed-credentials-success':
       annotate:
         Stream: AUDITD
-        Action: DISPOSED_CREDENTIALS
+        Action: CREDENTIALS_DISPOSED
         Status: PASSED
       translate:
         user[name]: User
@@ -72,7 +72,7 @@ event-details:
     'refreshed-credentials-success':
       annotate:
         Stream: AUDITD
-        Action: REFRESHED_CREDENTIALS
+        Action: CREDENTIALS_REFRESHED
         Status: PASSED
       translate:
         user[name]: User

--- a/extractors/OS/auditbeat.yaml
+++ b/extractors/OS/auditbeat.yaml
@@ -23,7 +23,6 @@ event-details:
         Action: LOGIN
         Status: PASSED
         AuthProto: '-'
-        Reason: '-'
       translate:
         user[name]: User
         source[ip]: SrcIP
@@ -45,7 +44,7 @@ event-details:
         Action: LOGIN
         Status: FAILED
         AuthProto: '-'
-        Reason: '-'
+        Reason: BAD_USER_PASSWORD
       translate:
         user[name]: User
         source[ip]: SrcIP 
@@ -83,7 +82,7 @@ event-details:
     'started-session-success':
       annotate:
         Stream: AUDITD
-        Action: SESSION_START
+        Action: SESSION_STARTED
         Status: PASSED
       translate:
         user[name]: User
@@ -93,7 +92,7 @@ event-details:
     'ended-session-success':
       annotate:
         Stream: AUDITD
-        Action: SESSION_END
+        Action: SESSION_ENDED
         Status: PASSED
       translate:
         user[name]: User
@@ -109,7 +108,6 @@ event-details:
     translate:
       host[hostname]: System
       '@timestamp': SystemTstamp
-
 
 - first-match: '\"category\":\[\"file\"'
   decoder: json
@@ -165,7 +163,6 @@ event-details:
       host[hostname]: System
       '@timestamp': SystemTstamp
 
-
 - first-match: '\"category\":\[\"process\"'
   decoder: json
   event-key-format: '{event[action]}'
@@ -173,7 +170,7 @@ event-details:
     'started-service':
       annotate:
         Stream: AUDITD
-        Action: SERVICE_START
+        Action: SERVICE_STARTED
         Status: PASSED
       translate:
         user[name]: User
@@ -183,7 +180,7 @@ event-details:
     'stopped-service':
       annotate:
         Stream: AUDITD
-        Action: SERVICE_STOP
+        Action: SERVICE_STOPPED
         Status: PASSED
       translate:
         user[name]: User


### PR DESCRIPTION
Added single quotes to master filter
For stream AUTHENTICATION, taken Reason: BAD_USER_PASSWORD
Added new mapping 'authenticated-failure', acquired-credentials-success', 'disposed-credentials-success', 'refreshed-credentials-success', 'started-session-success' and 'ended-session-success'
Added new mapping 'ran-commad' for AUDITD stream